### PR TITLE
Fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,88 @@
+{
+  "name": "bns",
+  "version": "0.14.0",
+  "lockfileVersion": 1,
+  "preserveSymlinks": "1",
+  "requires": true,
+  "dependencies": {
+    "bcrypto": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.4.0.tgz",
+      "integrity": "sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==",
+      "requires": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
+      }
+    },
+    "bfile": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
+      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg=="
+    },
+    "bheep": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "binet": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.6.tgz",
+      "integrity": "sha512-6pm+Gc3uNiiJZEv0k8JDWqQlo9ki/o9UNAkLmr0EGm7hI5MboOJVIOlO1nw3YuDkLHWN78OPsaC4JhRkn2jMLw==",
+      "requires": {
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bmocha": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.5.tgz",
+      "integrity": "sha512-hEO+jQC+6CMxdxSqKPjqAdIDvRWHfdGgsMh4fUmatkMewbYr2O6qMIbW7Lhcmkcnz8bwRHZuEdDaBt/16NofoA==",
+      "dev": true
+    },
+    "bs32": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+    },
+    "btcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A=="
+    },
+    "budp": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/budp/-/budp-0.1.6.tgz",
+      "integrity": "sha512-o+a8NPq3DhV91j4nInjht2md6mbU1XL+7ciPltP66rw5uD3KP1m5r8lA94LZVaPKcFdJ0l2HVVzRNxnY26Pefg=="
+    },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+    },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
+    },
+    "unbound": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.4.3.tgz",
+      "integrity": "sha512-2ISqZLXtzp1l9f1V8Yr6S+zuhXxEwE1CjKHjXULFDHJcfhc9Gm3mn19hdPp4rlNGEdCivKYGKjYe3WRGnafYdA==",
+      "optional": true,
+      "requires": {
+        "loady": "~0.0.5"
+      }
+    }
+  }
+}

--- a/test/dane-test.js
+++ b/test/dane-test.js
@@ -106,43 +106,41 @@ describe('DANE', function() {
   if (process.browser)
     return;
 
-  it('should verify spki+sha256 cert (www.ietf.org)', async () => {
+  it('should verify spki+sha256 cert (getfedora.org)', async () => {
+    // openssl s_client -showcerts -connect getfedora.org:443 < /dev/null
     const cert = fromBase64(`
-      MIIFUTCCBDmgAwIBAgIIITAshaEP0OswDQYJKoZIhvcNAQELBQAwgcYxCzAJBgNV
-      BAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMSUw
-      IwYDVQQKExxTdGFyZmllbGQgVGVjaG5vbG9naWVzLCBJbmMuMTMwMQYDVQQLEypo
-      dHRwOi8vY2VydHMuc3RhcmZpZWxkdGVjaC5jb20vcmVwb3NpdG9yeS8xNDAyBgNV
-      BAMTK1N0YXJmaWVsZCBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIw
-      HhcNMTcwNjEyMTAxMjAwWhcNMTgwODExMjMxMjUwWjA4MSEwHwYDVQQLExhEb21h
-      aW4gQ29udHJvbCBWYWxpZGF0ZWQxEzARBgNVBAMMCiouaWV0Zi5vcmcwggEiMA0G
-      CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2eMubW2zWELh8023dSdAP3LvdsNeC
-      KhPJZhIjdxr8o1+5PJ2MVMRgCaqe4asE5R+BuYfc9FDQCamqWOBZNvd3crwfhQW8
-      NZBM9JLbUgyObyip3X2cTkbFaKsa7SgNHOFYsd7VFntmuiEI+D/U5yzLjtBm4raV
-      oUHSsSatFYGYRhsOXf/DF/ld+oiqk7KckHTa2FetMJxMztHPUWoIW39lVkHmEpjZ
-      L4JN0T04hUqWvhYcx+69Rh46PToaTAsUkc2/a1T62i8jeZhHFS5jhS6mRLcwL461
-      7LtcqbU/4g2NZah6CbqIIC3dW6ylXP7qlTbGCXeesBUxAcHh9F5A8fSlAgMBAAGj
-      ggHOMIIByjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF
-      BQcDAjAOBgNVHQ8BAf8EBAMCBaAwPAYDVR0fBDUwMzAxoC+gLYYraHR0cDovL2Ny
-      bC5zdGFyZmllbGR0ZWNoLmNvbS9zZmlnMnMxLTU2LmNybDBjBgNVHSAEXDBaME4G
-      C2CGSAGG/W4BBxcBMD8wPQYIKwYBBQUHAgEWMWh0dHA6Ly9jZXJ0aWZpY2F0ZXMu
-      c3RhcmZpZWxkdGVjaC5jb20vcmVwb3NpdG9yeS8wCAYGZ4EMAQIBMIGGBggrBgEF
-      BQcBAQR6MHgwKgYIKwYBBQUHMAGGHmh0dHA6Ly9vY3NwLnN0YXJmaWVsZHRlY2gu
-      Y29tLzBKBggrBgEFBQcwAoY+aHR0cDovL2NlcnRpZmljYXRlcy5zdGFyZmllbGR0
-      ZWNoLmNvbS9yZXBvc2l0b3J5L3NmaWcyLmNydC5kZXIwHwYDVR0jBBgwFoAUJUWB
-      aFAmOD07LSy+zWrZtj2zZmMwHwYDVR0RBBgwFoIKKi5pZXRmLm9yZ4IIaWV0Zi5v
-      cmcwHQYDVR0OBBYEFAb+C6vY5nRu/MRzAoX3qUh+0TRPMA0GCSqGSIb3DQEBCwUA
-      A4IBAQDkjdd7Mz2F83bfBNjAS0uN0mGIn2Z67dcWP+klzp7JzGb+qdbPZsI0aHKZ
-      UEh0Pl71hcn8LlhYl+n7GJUGhW7CaOVqhzHkxfyfIls6BJ+pL6mIx5be8xqSV04b
-      zyPBZcPnuFdi/dXAgjE9iSFHfNH8gthiXgzgiIPIjQp2xuJDeQHWT5ZQ5gUxF8qP
-      ecO5L6IwMzZFRuE6SYzFynsOMOGjsPYJkYLm3JYwUulDz7OtRABwN5wegc5tTgq5
-      9HaFOULLCdMakLIRmMC0PzSI+m3+cYoZ6ue/8q9my7HgekcVMYQ5lRKncrs3GMxo
-      WNyYOpbGqBfooA8nwwE20fpacX2i
+      MIIEsTCCA5mgAwIBAgIQBOHnpNxc8vNtwCtCuF0VnzANBgkqhkiG9w0BAQsFADBs
+      MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+      d3cuZGlnaWNlcnQuY29tMSswKQYDVQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5j
+      ZSBFViBSb290IENBMB4XDTEzMTAyMjEyMDAwMFoXDTI4MTAyMjEyMDAwMFowcDEL
+      MAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3
+      LmRpZ2ljZXJ0LmNvbTEvMC0GA1UEAxMmRGlnaUNlcnQgU0hBMiBIaWdoIEFzc3Vy
+      YW5jZSBTZXJ2ZXIgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2
+      4C/CJAbIbQRf1+8KZAayfSImZRauQkCbztyfn3YHPsMwVYcZuU+UDlqUH1VWtMIC
+      Kq/QmO4LQNfE0DtyyBSe75CxEamu0si4QzrZCwvV1ZX1QK/IHe1NnF9Xt4ZQaJn1
+      itrSxwUfqJfJ3KSxgoQtxq2lnMcZgqaFD15EWCo3j/018QsIJzJa9buLnqS9UdAn
+      4t07QjOjBSjEuyjMmqwrIw14xnvmXnG3Sj4I+4G3FhahnSMSTeXXkgisdaScus0X
+      sh5ENWV/UyU50RwKmmMbGZJ0aAo3wsJSSMs5WqK24V3B3aAguCGikyZvFEohQcft
+      bZvySC/zA/WiaJJTL17jAgMBAAGjggFJMIIBRTASBgNVHRMBAf8ECDAGAQH/AgEA
+      MA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
+      NAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2Vy
+      dC5jb20wSwYDVR0fBEQwQjBAoD6gPIY6aHR0cDovL2NybDQuZGlnaWNlcnQuY29t
+      L0RpZ2lDZXJ0SGlnaEFzc3VyYW5jZUVWUm9vdENBLmNybDA9BgNVHSAENjA0MDIG
+      BFUdIAAwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQ
+      UzAdBgNVHQ4EFgQUUWj/kK8CB3U8zNllZGKiErhZcjswHwYDVR0jBBgwFoAUsT7D
+      aQP4v0cB1JgmGggC72NkK8MwDQYJKoZIhvcNAQELBQADggEBABiKlYkD5m3fXPwd
+      aOpKj4PWUS+Na0QWnqxj9dJubISZi6qBcYRb7TROsLd5kinMLYBq8I4g4Xmk/gNH
+      E+r1hspZcX30BJZr01lYPf7TMSVcGDiEo+afgv2MW5gxTs14nhr9hctJqvIni5ly
+      /D6q1UEL2tU2ob8cbkdJf17ZSHwD2f2LSaCYJkJA69aSEaRkCldUxPUd1gJea6zu
+      xICaEnL6VpPX/78whQYwvwt/Tv9XBZ0k7YXDK/umdaisLRbvfXknsuvCnQsH6qqF
+      0wGjIChBWUMo0oHjqvbsezt3tkBigAVBRQHvFwY+3sAzm2fTYS5yh+Rp/BIAV0Ae
+      cPUeybQ=
     `);
 
     // Hack for testing.
     dns._allowInsecure = true;
 
-    const rrs = await dns.resolveTLSA('www.ietf.org', 'tcp', 443);
+    const rrs = await dns.resolveTLSA('getfedora.org', 'tcp', 443);
 
     assert(Array.isArray(rrs));
     assert(rrs.length >= 1);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -32,456 +32,464 @@ if (process.browser)
   return;
 
 describe('Server', function() {
-  this.timeout(20000);
-
-  let server = null;
-  let dns = null;
-  let authServer = null;
-  let recServer = null;
-  let authQueries = 0;
-  let recQueries = 0;
-
-  it('should listen on port 5300', async () => {
-    server = new Server({
-      tcp: true,
-      maxConnections: 20,
-      edns: true,
-      dnssec: true
-    });
-
-    server.on('error', (err) => {
-      throw err;
-    });
-
-    const getAnswer = (type) => {
-      const txt = serverRecords[wire.typeToString(type)];
-
-      if (!Array.isArray(txt))
-        return null;
-
-      return wire.fromZone(txt.join('\n'));
-    };
-
-    server.on('query', (req, res, rinfo) => {
-      const [qs] = req.question;
-      const answer = getAnswer(qs.type);
-
-      if (!answer || !util.equal(qs.name, answer[0].name)) {
-        res.code = wire.codes.NXDOMAIN;
-        res.send();
-        return;
+  for (const inet6 of [true, false]) {
+    describe(`inet6: ${inet6}`, function() {
+      if (inet6) {
+        this.skip();
       }
 
-      res.answer = answer;
-      res.send();
+      this.timeout(20000);
+
+      let server = null;
+      let dns = null;
+      let authServer = null;
+      let recServer = null;
+      let authQueries = 0;
+      let recQueries = 0;
+
+      it('should listen on port 5300', async () => {
+        server = new Server({
+          tcp: true,
+          maxConnections: 20,
+          edns: true,
+          dnssec: true
+        });
+
+        server.on('error', (err) => {
+          throw err;
+        });
+
+        const getAnswer = (type) => {
+          const txt = serverRecords[wire.typeToString(type)];
+
+          if (!Array.isArray(txt))
+            return null;
+
+          return wire.fromZone(txt.join('\n'));
+        };
+
+        server.on('query', (req, res, rinfo) => {
+          const [qs] = req.question;
+          const answer = getAnswer(qs.type);
+
+          if (!answer || !util.equal(qs.name, answer[0].name)) {
+            res.code = wire.codes.NXDOMAIN;
+            res.send();
+            return;
+          }
+
+          res.answer = answer;
+          res.send();
+        });
+
+        await server.bind(5300, '127.0.0.1');
+      });
+
+      it('should instantiate resolver', async () => {
+        dns = new api.Resolver();
+
+        dns.setServers(['127.0.0.1:5300']);
+      });
+
+      it('should respond to A request', async () => {
+        assert.deepStrictEqual(await dns.lookup('icanhazip.com'), {
+          address: '147.75.40.2',
+          family: 4
+        });
+      });
+
+      it('should respond to PTR request', async () => {
+        assert.deepStrictEqual(await dns.lookupService('172.217.0.46', 80), {
+          hostname: 'lga15s43-in-f46.1e100.net',
+          service: 'http'
+        });
+      });
+
+      it('should respond to ANY request', async () => {
+        assert.deepStrictEqual(await dns.resolveAny('google.com'), [
+          { address: '216.58.195.78', ttl: 300, type: 'A' },
+          { address: '2607:f8b0:4005:807::200e', ttl: 300, type: 'AAAA' },
+          { entries: ['v=spf1 include:_spf.google.com ~all'], type: 'TXT' },
+          { exchange: 'aspmx.l.google.com', priority: 10, type: 'MX' },
+          { exchange: 'alt2.aspmx.l.google.com', priority: 30, type: 'MX' },
+          {
+            nsname: 'ns1.google.com',
+            hostmaster: 'dns-admin.google.com',
+            serial: 213603989,
+            refresh: 900,
+            retry: 900,
+            expire: 1800,
+            minttl: 60,
+            type: 'SOA'
+          },
+          {
+            entries: [
+              'facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95'
+            ],
+            type: 'TXT'
+          },
+          { exchange: 'alt4.aspmx.l.google.com', priority: 50, type: 'MX' },
+          { value: 'ns2.google.com', type: 'NS' },
+          { value: 'ns4.google.com', type: 'NS' },
+          { value: 'ns3.google.com', type: 'NS' },
+          { exchange: 'alt3.aspmx.l.google.com', priority: 40, type: 'MX' },
+          {
+            entries: ['docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e'],
+            type: 'TXT'
+          },
+          { value: 'ns1.google.com', type: 'NS' },
+          { exchange: 'alt1.aspmx.l.google.com', priority: 20, type: 'MX' }
+        ]);
+      });
+
+      it('should respond to A request', async () => {
+        assert.deepStrictEqual(await dns.resolve4('icanhazip.com'), [
+          '147.75.40.2'
+        ]);
+      });
+
+      it('should respond to AAAA request', async () => {
+        assert.deepStrictEqual(await dns.resolve6('icanhazip.com'), [
+          '2604:1380:1000:af00::1',
+          '2604:1380:3000:3b00::1',
+          '2604:1380:1:cd00::1'
+        ]);
+      });
+
+      it('should respond to CNAME request', async () => {
+        assert.deepStrictEqual(await dns.resolveCname('mail.google.com'), [
+          'googlemail.l.google.com'
+        ]);
+      });
+
+      it('should respond to MX request', async () => {
+        assert.deepStrictEqual(await dns.resolveMx('google.com'), [
+          { exchange: 'alt3.aspmx.l.google.com', priority: 40 },
+          { exchange: 'alt1.aspmx.l.google.com', priority: 20 },
+          { exchange: 'alt4.aspmx.l.google.com', priority: 50 },
+          { exchange: 'alt2.aspmx.l.google.com', priority: 30 },
+          { exchange: 'aspmx.l.google.com', priority: 10 }
+        ]);
+      });
+
+      it('should respond to NAPTR request', async () => {
+        assert.deepStrictEqual(await dns.resolveNaptr('apple.com'), [
+          {
+            flags: 'se',
+            service: 'SIPS+D2T',
+            regexp: '',
+            replacement: '_sips._tcp.apple.com',
+            order: 50,
+            preference: 50
+          },
+          {
+            flags: 'se',
+            service: 'SIP+D2T',
+            regexp: '',
+            replacement: '_sip._tcp.apple.com',
+            order: 90,
+            preference: 50
+          },
+          {
+            flags: 'se',
+            service: 'SIP+D2U',
+            regexp: '',
+            replacement: '_sip._udp.apple.com',
+            order: 100,
+            preference: 50
+          }
+        ]);
+      });
+
+      it('should respond to PTR request', async () => {
+        assert.deepStrictEqual(await dns.resolvePtr('46.0.217.172.in-addr.arpa.'), [
+          'lga15s43-in-f46.1e100.net',
+          'sfo07s26-in-f14.1e100.net',
+          'lga15s43-in-f14.1e100.net',
+          'lga15s43-in-f46.1e100.net',
+          'sfo07s26-in-f14.1e100.net',
+          'lga15s43-in-f14.1e100.net'
+        ]);
+      });
+
+      it('should respond to SOA request', async () => {
+        assert.deepStrictEqual(await dns.resolveSoa('google.com'), {
+          nsname: 'ns1.google.com',
+          hostmaster: 'dns-admin.google.com',
+          serial: 213603989,
+          refresh: 900,
+          retry: 900,
+          expire: 1800,
+          minttl: 60
+        });
+      });
+
+      it('should respond to SRV request', async () => {
+        assert.deepStrictEqual(
+          await dns.resolveSrv('_xmpp-server._tcp.gmail.com'),
+          [
+            { name: 'alt4.xmpp-server.l.google.com',
+              port: 5269,
+              priority: 20,
+              weight: 0 },
+            { name: 'alt3.xmpp-server.l.google.com',
+              port: 5269,
+              priority: 20,
+              weight: 0 },
+            { name: 'xmpp-server.l.google.com',
+              port: 5269,
+              priority: 5,
+              weight: 0 },
+            { name: 'alt1.xmpp-server.l.google.com',
+              port: 5269,
+              priority: 20,
+              weight: 0 },
+            { name: 'alt2.xmpp-server.l.google.com',
+              port: 5269,
+              priority: 20,
+              weight: 0 }
+          ]
+        );
+      });
+
+      it('should respond to TXT request', async () => {
+        assert.deepStrictEqual(await dns.resolveTxt('google.com'), [
+          ['facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95'],
+          ['docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e'],
+          ['v=spf1 include:_spf.google.com ~all']
+        ]);
+      });
+
+      it('should respond to PTR request', async () => {
+        assert.deepStrictEqual(await dns.reverse('172.217.0.46'), [
+          'lga15s43-in-f46.1e100.net',
+          'sfo07s26-in-f14.1e100.net',
+          'lga15s43-in-f14.1e100.net',
+          'lga15s43-in-f46.1e100.net',
+          'sfo07s26-in-f14.1e100.net',
+          'lga15s43-in-f14.1e100.net'
+        ]);
+      });
+
+      it('should close server', async () => {
+        await server.close();
+      });
+
+      it('should open authoritative server', async () => {
+        authServer = new AuthServer({
+          tcp: true,
+          edns: true,
+          dnssec: true
+        });
+
+        authServer.on('error', (err) => {
+          throw err;
+        });
+
+        authServer.on('query', () => {
+          authQueries += 1;
+        });
+
+        authServer.setOrigin('.');
+        authServer.setFile(ROOT_ZONE);
+
+        await authServer.bind(5301, '127.0.0.1');
+      });
+
+      it('should open recursive server', async () => {
+        recServer = new RecursiveServer({
+          tcp: true,
+          inet6,
+          edns: true,
+          dnssec: true
+        });
+
+        recServer.on('error', (err) => {
+          throw err;
+        });
+
+        recServer.on('query', () => {
+          recQueries += 1;
+        });
+
+        recServer.resolver.setStub(
+          '127.0.0.1',
+          5301,
+          Record.fromString(KSK_2010)
+        );
+
+        await recServer.bind(5302, '127.0.0.1');
+      });
+
+      it('should query authoritative server (stub)', async () => {
+        const stub = new StubResolver({
+          rd: false,
+          cd: false,
+          edns: true,
+          dnssec: true,
+          hosts: [
+            ['localhost.', '127.0.0.1'],
+            ['localhost.', '::1']
+          ],
+          servers: ['127.0.0.1:5301']
+        });
+
+        stub.on('error', (err) => {
+          throw err;
+        });
+
+        await stub.open();
+
+        {
+          const msg = await stub.lookup('com.', types.NS);
+          assert(msg.code === codes.NOERROR);
+          assert(!msg.aa);
+
+          const expect = wire.fromZone(comResponse);
+          assert.deepStrictEqual(msg.authority, expect);
+
+          const glue = wire.fromZone(comGlue);
+          assert.deepStrictEqual(msg.additional, glue);
+        }
+
+        {
+          const msg = await stub.lookup('idontexist.', types.A);
+          assert(!msg.aa);
+          assert(msg.code === codes.NXDOMAIN);
+          assert(msg.answer.length === 0);
+
+          const expect = wire.fromZone(nxResponse);
+          assert.deepStrictEqual(msg.authority, expect);
+        }
+
+        await stub.close();
+      });
+
+      it('should query recursive server (stub)', async () => {
+        const stub = new StubResolver({
+          rd: true,
+          cd: false,
+          edns: true,
+          dnssec: true,
+          hosts: [
+            ['localhost.', '127.0.0.1'],
+            ['localhost.', '::1']
+          ],
+          servers: ['127.0.0.1:5302']
+        });
+
+        stub.on('error', (err) => {
+          throw err;
+        });
+
+        await stub.open();
+
+        const msg = await stub.lookup('google.com.', types.A);
+        assert(msg.code === codes.NOERROR);
+        assert(msg.answer.length > 0);
+        assert(msg.answer[0].name === 'google.com.');
+        assert(msg.answer[0].type === types.A);
+
+        await stub.close();
+      });
+
+      it('should do a recursive resolution', async () => {
+        const res = new RecursiveResolver({
+          tcp: true,
+          inet6,
+          edns: true,
+          dnssec: true
+        });
+
+        res.setStub('127.0.0.1', 5301, Record.fromString(KSK_2010));
+
+        res.on('error', (err) => {
+          throw err;
+        });
+
+        await res.open();
+
+        const msg = await res.lookup('google.com.', types.A);
+        assert(msg.code === codes.NOERROR);
+        assert(msg.answer.length > 0);
+        assert(msg.answer[0].name === 'google.com.');
+        assert(msg.answer[0].type === types.A);
+
+        await res.close();
+      });
+
+      it('should do a recursive resolution (unbound)', async () => {
+        const res = new UnboundResolver({
+          tcp: true,
+          inet6,
+          edns: true,
+          dnssec: true
+        });
+
+        res.setStub('127.0.0.1', 5301, Record.fromString(KSK_2010));
+
+        res.on('error', (err) => {
+          throw err;
+        });
+
+        await res.open();
+
+        const msg = await res.lookup('google.com.', types.A);
+        assert(msg.code === codes.NOERROR);
+        assert(msg.answer.length > 0);
+        assert(msg.answer[0].name === 'google.com.');
+        assert(msg.answer[0].type === types.A);
+
+        await res.close();
+      });
+
+      it('should do a root resolution', async () => {
+        const res = new RootResolver({
+          tcp: true,
+          inet6,
+          edns: true,
+          dnssec: true
+        });
+
+        res.on('error', (err) => {
+          throw err;
+        });
+
+        res.servers = [{
+          host: '127.0.0.1',
+          port: 5301
+        }];
+
+        await res.open();
+
+        util.fakeTime('2018-08-05:00:00.000Z');
+
+        const msg = await res.lookup('com.');
+        assert(msg.code === codes.NOERROR);
+        assert(!msg.aa);
+        assert(msg.ad);
+
+        const expect = wire.fromZone(comResponse);
+        expect.pop(); // pop signature
+        assert.deepStrictEqual(msg.authority, expect);
+
+        const glue = wire.fromZone(comGlue);
+        assert.deepStrictEqual(msg.additional, glue);
+
+        util.fakeTime();
+
+        await res.close();
+      });
+
+      it('should have total requests', () => {
+        assert.strictEqual(authQueries, 16);
+        assert.strictEqual(recQueries, 1);
+      });
+
+      it('should close servers', async () => {
+        await recServer.close();
+        await authServer.close();
+      });
     });
-
-    await server.bind(5300, '127.0.0.1');
-  });
-
-  it('should instantiate resolver', async () => {
-    dns = new api.Resolver();
-
-    dns.setServers(['127.0.0.1:5300']);
-  });
-
-  it('should respond to A request', async () => {
-    assert.deepStrictEqual(await dns.lookup('icanhazip.com'), {
-      address: '147.75.40.2',
-      family: 4
-    });
-  });
-
-  it('should respond to PTR request', async () => {
-    assert.deepStrictEqual(await dns.lookupService('172.217.0.46', 80), {
-      hostname: 'lga15s43-in-f46.1e100.net',
-      service: 'http'
-    });
-  });
-
-  it('should respond to ANY request', async () => {
-    assert.deepStrictEqual(await dns.resolveAny('google.com'), [
-      { address: '216.58.195.78', ttl: 300, type: 'A' },
-      { address: '2607:f8b0:4005:807::200e', ttl: 300, type: 'AAAA' },
-      { entries: ['v=spf1 include:_spf.google.com ~all'], type: 'TXT' },
-      { exchange: 'aspmx.l.google.com', priority: 10, type: 'MX' },
-      { exchange: 'alt2.aspmx.l.google.com', priority: 30, type: 'MX' },
-      {
-        nsname: 'ns1.google.com',
-        hostmaster: 'dns-admin.google.com',
-        serial: 213603989,
-        refresh: 900,
-        retry: 900,
-        expire: 1800,
-        minttl: 60,
-        type: 'SOA'
-      },
-      {
-        entries: [
-          'facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95'
-        ],
-        type: 'TXT'
-      },
-      { exchange: 'alt4.aspmx.l.google.com', priority: 50, type: 'MX' },
-      { value: 'ns2.google.com', type: 'NS' },
-      { value: 'ns4.google.com', type: 'NS' },
-      { value: 'ns3.google.com', type: 'NS' },
-      { exchange: 'alt3.aspmx.l.google.com', priority: 40, type: 'MX' },
-      {
-        entries: ['docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e'],
-        type: 'TXT'
-      },
-      { value: 'ns1.google.com', type: 'NS' },
-      { exchange: 'alt1.aspmx.l.google.com', priority: 20, type: 'MX' }
-    ]);
-  });
-
-  it('should respond to A request', async () => {
-    assert.deepStrictEqual(await dns.resolve4('icanhazip.com'), [
-      '147.75.40.2'
-    ]);
-  });
-
-  it('should respond to AAAA request', async () => {
-    assert.deepStrictEqual(await dns.resolve6('icanhazip.com'), [
-      '2604:1380:1000:af00::1',
-      '2604:1380:3000:3b00::1',
-      '2604:1380:1:cd00::1'
-    ]);
-  });
-
-  it('should respond to CNAME request', async () => {
-    assert.deepStrictEqual(await dns.resolveCname('mail.google.com'), [
-      'googlemail.l.google.com'
-    ]);
-  });
-
-  it('should respond to MX request', async () => {
-    assert.deepStrictEqual(await dns.resolveMx('google.com'), [
-      { exchange: 'alt3.aspmx.l.google.com', priority: 40 },
-      { exchange: 'alt1.aspmx.l.google.com', priority: 20 },
-      { exchange: 'alt4.aspmx.l.google.com', priority: 50 },
-      { exchange: 'alt2.aspmx.l.google.com', priority: 30 },
-      { exchange: 'aspmx.l.google.com', priority: 10 }
-    ]);
-  });
-
-  it('should respond to NAPTR request', async () => {
-    assert.deepStrictEqual(await dns.resolveNaptr('apple.com'), [
-      {
-        flags: 'se',
-        service: 'SIPS+D2T',
-        regexp: '',
-        replacement: '_sips._tcp.apple.com',
-        order: 50,
-        preference: 50
-      },
-      {
-        flags: 'se',
-        service: 'SIP+D2T',
-        regexp: '',
-        replacement: '_sip._tcp.apple.com',
-        order: 90,
-        preference: 50
-      },
-      {
-        flags: 'se',
-        service: 'SIP+D2U',
-        regexp: '',
-        replacement: '_sip._udp.apple.com',
-        order: 100,
-        preference: 50
-      }
-    ]);
-  });
-
-  it('should respond to PTR request', async () => {
-    assert.deepStrictEqual(await dns.resolvePtr('46.0.217.172.in-addr.arpa.'), [
-      'lga15s43-in-f46.1e100.net',
-      'sfo07s26-in-f14.1e100.net',
-      'lga15s43-in-f14.1e100.net',
-      'lga15s43-in-f46.1e100.net',
-      'sfo07s26-in-f14.1e100.net',
-      'lga15s43-in-f14.1e100.net'
-    ]);
-  });
-
-  it('should respond to SOA request', async () => {
-    assert.deepStrictEqual(await dns.resolveSoa('google.com'), {
-      nsname: 'ns1.google.com',
-      hostmaster: 'dns-admin.google.com',
-      serial: 213603989,
-      refresh: 900,
-      retry: 900,
-      expire: 1800,
-      minttl: 60
-    });
-  });
-
-  it('should respond to SRV request', async () => {
-    assert.deepStrictEqual(
-      await dns.resolveSrv('_xmpp-server._tcp.gmail.com'),
-      [
-        { name: 'alt4.xmpp-server.l.google.com',
-          port: 5269,
-          priority: 20,
-          weight: 0 },
-        { name: 'alt3.xmpp-server.l.google.com',
-          port: 5269,
-          priority: 20,
-          weight: 0 },
-        { name: 'xmpp-server.l.google.com',
-          port: 5269,
-          priority: 5,
-          weight: 0 },
-        { name: 'alt1.xmpp-server.l.google.com',
-          port: 5269,
-          priority: 20,
-          weight: 0 },
-        { name: 'alt2.xmpp-server.l.google.com',
-          port: 5269,
-          priority: 20,
-          weight: 0 }
-      ]
-    );
-  });
-
-  it('should respond to TXT request', async () => {
-    assert.deepStrictEqual(await dns.resolveTxt('google.com'), [
-      ['facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95'],
-      ['docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e'],
-      ['v=spf1 include:_spf.google.com ~all']
-    ]);
-  });
-
-  it('should respond to PTR request', async () => {
-    assert.deepStrictEqual(await dns.reverse('172.217.0.46'), [
-      'lga15s43-in-f46.1e100.net',
-      'sfo07s26-in-f14.1e100.net',
-      'lga15s43-in-f14.1e100.net',
-      'lga15s43-in-f46.1e100.net',
-      'sfo07s26-in-f14.1e100.net',
-      'lga15s43-in-f14.1e100.net'
-    ]);
-  });
-
-  it('should close server', async () => {
-    await server.close();
-  });
-
-  it('should open authoritative server', async () => {
-    authServer = new AuthServer({
-      tcp: true,
-      edns: true,
-      dnssec: true
-    });
-
-    authServer.on('error', (err) => {
-      throw err;
-    });
-
-    authServer.on('query', () => {
-      authQueries += 1;
-    });
-
-    authServer.setOrigin('.');
-    authServer.setFile(ROOT_ZONE);
-
-    await authServer.bind(5301, '127.0.0.1');
-  });
-
-  it('should open recursive server', async () => {
-    recServer = new RecursiveServer({
-      tcp: true,
-      inet6: true,
-      edns: true,
-      dnssec: true
-    });
-
-    recServer.on('error', (err) => {
-      throw err;
-    });
-
-    recServer.on('query', () => {
-      recQueries += 1;
-    });
-
-    recServer.resolver.setStub(
-      '127.0.0.1',
-      5301,
-      Record.fromString(KSK_2010)
-    );
-
-    await recServer.bind(5302, '127.0.0.1');
-  });
-
-  it('should query authoritative server (stub)', async () => {
-    const stub = new StubResolver({
-      rd: false,
-      cd: false,
-      edns: true,
-      dnssec: true,
-      hosts: [
-        ['localhost.', '127.0.0.1'],
-        ['localhost.', '::1']
-      ],
-      servers: ['127.0.0.1:5301']
-    });
-
-    stub.on('error', (err) => {
-      throw err;
-    });
-
-    await stub.open();
-
-    {
-      const msg = await stub.lookup('com.', types.NS);
-      assert(msg.code === codes.NOERROR);
-      assert(!msg.aa);
-
-      const expect = wire.fromZone(comResponse);
-      assert.deepStrictEqual(msg.authority, expect);
-
-      const glue = wire.fromZone(comGlue);
-      assert.deepStrictEqual(msg.additional, glue);
-    }
-
-    {
-      const msg = await stub.lookup('idontexist.', types.A);
-      assert(!msg.aa);
-      assert(msg.code === codes.NXDOMAIN);
-      assert(msg.answer.length === 0);
-
-      const expect = wire.fromZone(nxResponse);
-      assert.deepStrictEqual(msg.authority, expect);
-    }
-
-    await stub.close();
-  });
-
-  it('should query recursive server (stub)', async () => {
-    const stub = new StubResolver({
-      rd: true,
-      cd: false,
-      edns: true,
-      dnssec: true,
-      hosts: [
-        ['localhost.', '127.0.0.1'],
-        ['localhost.', '::1']
-      ],
-      servers: ['127.0.0.1:5302']
-    });
-
-    stub.on('error', (err) => {
-      throw err;
-    });
-
-    await stub.open();
-
-    const msg = await stub.lookup('google.com.', types.A);
-    assert(msg.code === codes.NOERROR);
-    assert(msg.answer.length > 0);
-    assert(msg.answer[0].name === 'google.com.');
-    assert(msg.answer[0].type === types.A);
-
-    await stub.close();
-  });
-
-  it('should do a recursive resolution', async () => {
-    const res = new RecursiveResolver({
-      tcp: true,
-      inet6: true,
-      edns: true,
-      dnssec: true
-    });
-
-    res.setStub('127.0.0.1', 5301, Record.fromString(KSK_2010));
-
-    res.on('error', (err) => {
-      throw err;
-    });
-
-    await res.open();
-
-    const msg = await res.lookup('google.com.', types.A);
-    assert(msg.code === codes.NOERROR);
-    assert(msg.answer.length > 0);
-    assert(msg.answer[0].name === 'google.com.');
-    assert(msg.answer[0].type === types.A);
-
-    await res.close();
-  });
-
-  it('should do a recursive resolution (unbound)', async () => {
-    const res = new UnboundResolver({
-      tcp: true,
-      inet6: true,
-      edns: true,
-      dnssec: true
-    });
-
-    res.setStub('127.0.0.1', 5301, Record.fromString(KSK_2010));
-
-    res.on('error', (err) => {
-      throw err;
-    });
-
-    await res.open();
-
-    const msg = await res.lookup('google.com.', types.A);
-    assert(msg.code === codes.NOERROR);
-    assert(msg.answer.length > 0);
-    assert(msg.answer[0].name === 'google.com.');
-    assert(msg.answer[0].type === types.A);
-
-    await res.close();
-  });
-
-  it('should do a root resolution', async () => {
-    const res = new RootResolver({
-      tcp: true,
-      inet6: true,
-      edns: true,
-      dnssec: true
-    });
-
-    res.on('error', (err) => {
-      throw err;
-    });
-
-    res.servers = [{
-      host: '127.0.0.1',
-      port: 5301
-    }];
-
-    await res.open();
-
-    util.fakeTime('2018-08-05:00:00.000Z');
-
-    const msg = await res.lookup('com.');
-    assert(msg.code === codes.NOERROR);
-    assert(!msg.aa);
-    assert(msg.ad);
-
-    const expect = wire.fromZone(comResponse);
-    expect.pop(); // pop signature
-    assert.deepStrictEqual(msg.authority, expect);
-
-    const glue = wire.fromZone(comGlue);
-    assert.deepStrictEqual(msg.additional, glue);
-
-    util.fakeTime();
-
-    await res.close();
-  });
-
-  it('should have total requests', () => {
-    assert.strictEqual(authQueries, 16);
-    assert.strictEqual(recQueries, 1);
-  });
-
-  it('should close servers', async () => {
-    await recServer.close();
-    await authServer.close();
-  });
+  }
 });

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -33,6 +33,13 @@ if (process.browser)
 
 describe('Server', function() {
   for (const inet6 of [true, false]) {
+    const hosts = [
+      ['localhost.', '127.0.0.1']
+    ];
+
+    if (inet6)
+      hosts.push(['localhost.', '::1']);
+
     describe(`inet6: ${inet6}`, function() {
       if (inet6) {
         this.skip();
@@ -327,10 +334,7 @@ describe('Server', function() {
           cd: false,
           edns: true,
           dnssec: true,
-          hosts: [
-            ['localhost.', '127.0.0.1'],
-            ['localhost.', '::1']
-          ],
+          hosts,
           servers: ['127.0.0.1:5301']
         });
 
@@ -371,10 +375,7 @@ describe('Server', function() {
           cd: false,
           edns: true,
           dnssec: true,
-          hosts: [
-            ['localhost.', '127.0.0.1'],
-            ['localhost.', '::1']
-          ],
+          hosts,
           servers: ['127.0.0.1:5302']
         });
 

--- a/test/tlsa-test.js
+++ b/test/tlsa-test.js
@@ -214,43 +214,40 @@ describe('TLSA', function() {
   if (process.browser)
     return;
 
-  it('should verify spki+sha256 cert (www.ietf.org)', async () => {
+  it('should verify spki+sha256 cert (getfedora.org)', async () => {
     const cert = fromBase64(`
-      MIIFUTCCBDmgAwIBAgIIITAshaEP0OswDQYJKoZIhvcNAQELBQAwgcYxCzAJBgNV
-      BAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQHEwpTY290dHNkYWxlMSUw
-      IwYDVQQKExxTdGFyZmllbGQgVGVjaG5vbG9naWVzLCBJbmMuMTMwMQYDVQQLEypo
-      dHRwOi8vY2VydHMuc3RhcmZpZWxkdGVjaC5jb20vcmVwb3NpdG9yeS8xNDAyBgNV
-      BAMTK1N0YXJmaWVsZCBTZWN1cmUgQ2VydGlmaWNhdGUgQXV0aG9yaXR5IC0gRzIw
-      HhcNMTcwNjEyMTAxMjAwWhcNMTgwODExMjMxMjUwWjA4MSEwHwYDVQQLExhEb21h
-      aW4gQ29udHJvbCBWYWxpZGF0ZWQxEzARBgNVBAMMCiouaWV0Zi5vcmcwggEiMA0G
-      CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2eMubW2zWELh8023dSdAP3LvdsNeC
-      KhPJZhIjdxr8o1+5PJ2MVMRgCaqe4asE5R+BuYfc9FDQCamqWOBZNvd3crwfhQW8
-      NZBM9JLbUgyObyip3X2cTkbFaKsa7SgNHOFYsd7VFntmuiEI+D/U5yzLjtBm4raV
-      oUHSsSatFYGYRhsOXf/DF/ld+oiqk7KckHTa2FetMJxMztHPUWoIW39lVkHmEpjZ
-      L4JN0T04hUqWvhYcx+69Rh46PToaTAsUkc2/a1T62i8jeZhHFS5jhS6mRLcwL461
-      7LtcqbU/4g2NZah6CbqIIC3dW6ylXP7qlTbGCXeesBUxAcHh9F5A8fSlAgMBAAGj
-      ggHOMIIByjAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF
-      BQcDAjAOBgNVHQ8BAf8EBAMCBaAwPAYDVR0fBDUwMzAxoC+gLYYraHR0cDovL2Ny
-      bC5zdGFyZmllbGR0ZWNoLmNvbS9zZmlnMnMxLTU2LmNybDBjBgNVHSAEXDBaME4G
-      C2CGSAGG/W4BBxcBMD8wPQYIKwYBBQUHAgEWMWh0dHA6Ly9jZXJ0aWZpY2F0ZXMu
-      c3RhcmZpZWxkdGVjaC5jb20vcmVwb3NpdG9yeS8wCAYGZ4EMAQIBMIGGBggrBgEF
-      BQcBAQR6MHgwKgYIKwYBBQUHMAGGHmh0dHA6Ly9vY3NwLnN0YXJmaWVsZHRlY2gu
-      Y29tLzBKBggrBgEFBQcwAoY+aHR0cDovL2NlcnRpZmljYXRlcy5zdGFyZmllbGR0
-      ZWNoLmNvbS9yZXBvc2l0b3J5L3NmaWcyLmNydC5kZXIwHwYDVR0jBBgwFoAUJUWB
-      aFAmOD07LSy+zWrZtj2zZmMwHwYDVR0RBBgwFoIKKi5pZXRmLm9yZ4IIaWV0Zi5v
-      cmcwHQYDVR0OBBYEFAb+C6vY5nRu/MRzAoX3qUh+0TRPMA0GCSqGSIb3DQEBCwUA
-      A4IBAQDkjdd7Mz2F83bfBNjAS0uN0mGIn2Z67dcWP+klzp7JzGb+qdbPZsI0aHKZ
-      UEh0Pl71hcn8LlhYl+n7GJUGhW7CaOVqhzHkxfyfIls6BJ+pL6mIx5be8xqSV04b
-      zyPBZcPnuFdi/dXAgjE9iSFHfNH8gthiXgzgiIPIjQp2xuJDeQHWT5ZQ5gUxF8qP
-      ecO5L6IwMzZFRuE6SYzFynsOMOGjsPYJkYLm3JYwUulDz7OtRABwN5wegc5tTgq5
-      9HaFOULLCdMakLIRmMC0PzSI+m3+cYoZ6ue/8q9my7HgekcVMYQ5lRKncrs3GMxo
-      WNyYOpbGqBfooA8nwwE20fpacX2i
+      MIIEsTCCA5mgAwIBAgIQBOHnpNxc8vNtwCtCuF0VnzANBgkqhkiG9w0BAQsFADBs
+      MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+      d3cuZGlnaWNlcnQuY29tMSswKQYDVQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5j
+      ZSBFViBSb290IENBMB4XDTEzMTAyMjEyMDAwMFoXDTI4MTAyMjEyMDAwMFowcDEL
+      MAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3
+      LmRpZ2ljZXJ0LmNvbTEvMC0GA1UEAxMmRGlnaUNlcnQgU0hBMiBIaWdoIEFzc3Vy
+      YW5jZSBTZXJ2ZXIgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2
+      4C/CJAbIbQRf1+8KZAayfSImZRauQkCbztyfn3YHPsMwVYcZuU+UDlqUH1VWtMIC
+      Kq/QmO4LQNfE0DtyyBSe75CxEamu0si4QzrZCwvV1ZX1QK/IHe1NnF9Xt4ZQaJn1
+      itrSxwUfqJfJ3KSxgoQtxq2lnMcZgqaFD15EWCo3j/018QsIJzJa9buLnqS9UdAn
+      4t07QjOjBSjEuyjMmqwrIw14xnvmXnG3Sj4I+4G3FhahnSMSTeXXkgisdaScus0X
+      sh5ENWV/UyU50RwKmmMbGZJ0aAo3wsJSSMs5WqK24V3B3aAguCGikyZvFEohQcft
+      bZvySC/zA/WiaJJTL17jAgMBAAGjggFJMIIBRTASBgNVHRMBAf8ECDAGAQH/AgEA
+      MA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIw
+      NAYIKwYBBQUHAQEEKDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2Vy
+      dC5jb20wSwYDVR0fBEQwQjBAoD6gPIY6aHR0cDovL2NybDQuZGlnaWNlcnQuY29t
+      L0RpZ2lDZXJ0SGlnaEFzc3VyYW5jZUVWUm9vdENBLmNybDA9BgNVHSAENjA0MDIG
+      BFUdIAAwKjAoBggrBgEFBQcCARYcaHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQ
+      UzAdBgNVHQ4EFgQUUWj/kK8CB3U8zNllZGKiErhZcjswHwYDVR0jBBgwFoAUsT7D
+      aQP4v0cB1JgmGggC72NkK8MwDQYJKoZIhvcNAQELBQADggEBABiKlYkD5m3fXPwd
+      aOpKj4PWUS+Na0QWnqxj9dJubISZi6qBcYRb7TROsLd5kinMLYBq8I4g4Xmk/gNH
+      E+r1hspZcX30BJZr01lYPf7TMSVcGDiEo+afgv2MW5gxTs14nhr9hctJqvIni5ly
+      /D6q1UEL2tU2ob8cbkdJf17ZSHwD2f2LSaCYJkJA69aSEaRkCldUxPUd1gJea6zu
+      xICaEnL6VpPX/78whQYwvwt/Tv9XBZ0k7YXDK/umdaisLRbvfXknsuvCnQsH6qqF
+      0wGjIChBWUMo0oHjqvbsezt3tkBigAVBRQHvFwY+3sAzm2fTYS5yh+Rp/BIAV0Ae
+      cPUeybQ=
     `);
 
     // Hack for testing.
     dns._allowInsecure = true;
 
-    const rrs = await dns.resolveTLSA('www.ietf.org', 'tcp', 443);
+    const rrs = await dns.resolveTLSA('getfedora.org', 'tcp', 443);
 
     assert(Array.isArray(rrs));
     assert(rrs.length >= 1);


### PR DESCRIPTION
Mainly for CI, this updates the TLSA test with a working example from `getfedora.com` and runs the server test with ipv6 both enabled and disabled (I can't reach ipv6 from my home system and I don't think github actions can either). Right now, the ipv6 tests are just skipped. if we can figure out a way to add ipv6 to our github actions that'd be ideal.